### PR TITLE
Add config option to Configurable#load to pass a hash with loaded config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Loading the configurations
 Adjust.load(environment: 'test') # => {...}
 Adjust.load('path/to/adjust.yml')  # => {...}
 Adjust.load('path/to/adjust.yml', environment: 'staging') # => {...}
+Adjust.load(config: {...}) # => {...}
+Adjust.load(config: {...}, environment: 'staging') # => {...}
+Adjust.load(config: Rails.application.secrets.adjust) # => {...}
 
 ```
 

--- a/lib/adjust/core/configurable.rb
+++ b/lib/adjust/core/configurable.rb
@@ -1,8 +1,8 @@
 module Adjust
   module Core
     module Configurable
-      def load(path = 'config/adjust.yml', environment: nil)
-        configuration.load path, environment: environment
+      def load(path = 'config/adjust.yml', config: nil, environment: nil)
+        configuration.load path, config: config, environment: environment
       end
 
       def configuration

--- a/lib/adjust/core/configuration.rb
+++ b/lib/adjust/core/configuration.rb
@@ -18,7 +18,7 @@ module Adjust
       end
 
       def active
-        configurations[environment]
+        configurations.fetch(environment, configurations)
       end
 
       def active_environment

--- a/lib/adjust/core/configuration.rb
+++ b/lib/adjust/core/configuration.rb
@@ -4,9 +4,9 @@ require 'erb'
 module Adjust
   module Core
     class Configuration
-      def load(path, environment: nil)
+      def load(path, config: nil, environment: nil)
         @environment = environment || default_environment
-        @configurations = read_configurations path
+        @configurations = config || read_configurations(path)
       end
 
       def environment


### PR DESCRIPTION
I've added an optional parameter to Configurable#load to allow load config from a loaded hash. I think this can be specialy useful on rails projects, adding specific entry on secrets.yml:
```yaml
development:
  secret_key_base: 3b7cd727ee24e8444053437c36cc66c3
  adjust:
    environment: sandbox
    dev_app:
      app_token: app_token
      event1:
        event_token: event_token
```
Note that on this situation, Rails load secrets for specific environment, so I've adapted Configuration#active to allow work with config hash without environments, this allow load config like that:
```ruby
Adjust.load(config: Rails.application.secrets.adjust) # => {...}
```